### PR TITLE
Multi-paragraph footnotes appear broken

### DIFF
--- a/tests/extrafootnotes.t
+++ b/tests/extrafootnotes.t
@@ -18,6 +18,17 @@ try -ffootnote 'footnotes (-ffootnote)' "$FOOTIE" \
 </ol>
 </div>'
 
+try -ffootnote 'footnotes (-ffootnote)' "$FOOTIE
+    second" \
+'<p>I haz a footnote<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup></p>
+<div class="footnotes">
+<hr/>
+<ol>
+<li id="fn:1">
+<p>yes?</p><p>second<a href="#fnref:1" rev="footnote">&#8617;</a></p></li>
+</ol>
+</div>'
+
 try -ffootnote -Cfoot 'footnotes (-ffootnote -Cfoot)' "$FOOTIE" \
 '<p>I haz a footnote<sup id="footref:1"><a href="#foot:1" rel="footnote">1</a></sup></p>
 <div class="footnotes">


### PR DESCRIPTION
I've added a test case below that illustrates the problem, and you can see http://michelf.ca/projects/php-markdown/extra/#footnotes for the documented-but-unsupported behavior. Instead, Discount is currently adding later paragraphs at the end of the main body before the footnotes begin.

I started to look at https://github.com/Orc/discount/blob/master/markdown.c#L996-L1000, but was unable to make much progress. It's also possible there's a mistake in my Markdown, or I've misunderstood the documented behavior. Thanks!
